### PR TITLE
bluetoothd: allow rw access to /dev/hidraw children

### DIFF
--- a/apparmor.d/usr.lib.bluetooth.bluetoothd
+++ b/apparmor.d/usr.lib.bluetooth.bluetoothd
@@ -24,6 +24,7 @@ include <tunables/global>
 
 	/dev/rfkill rw,
 	/dev/uinput rw,
+	/dev/hidraw/{,**} rw,
 
 	/sys/devices/{,**} r,
 	/run/udev/{,**} r,


### PR DESCRIPTION
Some bluetooth devices (like sixaxis controllers) need access to hidraw nodes for out-of-band USB pairing.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>